### PR TITLE
adding vged.hpp and spdlog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "vendor/SPIRV-Headers"]
 	path = vendor/SPIRV-Headers
 	url = https://github.com/KhronosGroup/SPIRV-Headers.git
+[submodule "vendor/spdlog"]
+	path = vendor/spdlog
+	url = https://github.com/gabime/spdlog

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br>
 A C++ Game Engine for Linux, Windows, and macOS<br>
 <br>
-Clone or download the repo and from the top level directory build using ./build.sh<br>
+Clone or download the repo and from the top level directory build using "./build.sh" or "./build.sh release"<br>
 
 ## File structure and engine structure
 |-application<br>

--- a/application/example_game/CMakeLists.txt
+++ b/application/example_game/CMakeLists.txt
@@ -1,2 +1,15 @@
 cmake_minimum_required(VERSION 3.11.0)
-project(Application VERSION 0.0.1)
+project(example_game VERSION 0.0.1)
+
+file(GLOB_RECURSE SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+file(GLOB_RECURSE HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+
+set(CMAKE_CXX_STANDARD 20)
+
+include_directories(${PROJECT_NAME}
+    ../../engine
+    ../../vendor/spdlog/include
+)
+
+add_executable(${PROJECT_NAME} ${SRC_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} LINK_PUBLIC engine)

--- a/application/example_game/main.cpp
+++ b/application/example_game/main.cpp
@@ -1,6 +1,20 @@
-#include <iostream>
+#include "vged.hpp"
+#include "graphics/device.hpp"
+#include "GLFW/glfw3.h"
 
-int main() {
-    std::cout << "Vulkan Game Engine Dev!\n";
+using namespace VGED::Engine;
+
+int _main() {
+
+    VGED::Log::init();
+    LOG_APP_INFO("Vulkan Game Engine Dev!");
+
+    Window window(1280, 720, "VGED Engine");
+    Device device(&window);
+
+    while(!window.should_close()) {
+        glfwPollEvents();
+    }
+
     return 0;
 }

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,19 @@
 #!/bin/bash
-cmake -S . -B build
-cmake --build build
+
+target=debug
+
+if [[ $1 = "release" ]]
+then
+  target=release
+fi
+
+# build the engine
+if [[ $target = "release" ]]
+then
+  echo "Building release target. Validation layers will be disabled"
+  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+else
+  echo "Building debug target"
+  cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+fi
+cd build && make VERBOSE=1

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.11.0)
-project(Editor VERSION 0.0.1)
+project(editor VERSION 0.0.1)
 
 file(GLOB_RECURSE SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 file(GLOB_RECURSE HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 
-add_executable(Editor ${SRC_FILES} ${HEADER_FILES})
-target_link_libraries(Editor LINK_PUBLIC Engine)
+set(CMAKE_CXX_STANDARD 20)
+
+include_directories(${PROJECT_NAME}
+    ../engine
+    ../vendor/spdlog/include
+)
+
+add_executable(${PROJECT_NAME} ${SRC_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} LINK_PUBLIC engine)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11.0)
-project(Engine VERSION 0.0.1)
+project(engine VERSION 0.0.1)
 
 file(GLOB_RECURSE SOURCES ${PROJECT_SOURCE_DIR}/*.cpp)
 
@@ -10,8 +10,10 @@ add_library(${PROJECT_NAME} ${SOURCES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build")
 
 include_directories(${PROJECT_NAME}
+    ./
+    ../vendor/
+    ../vendor/spdlog/include/
     ${Vulkan_INCLUDE_DIRS}
-    src
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/engine/log/log.cpp
+++ b/engine/log/log.cpp
@@ -1,0 +1,40 @@
+
+
+#include <vector>
+
+#include "log/log.hpp"
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/basic_file_sink.h>
+
+namespace VGED
+{
+
+    std::shared_ptr<spdlog::logger> Log::m_EngineLogger;
+    std::shared_ptr<spdlog::logger> Log::m_AppLogger;
+
+    bool Log::init() {
+        bool ok = false;
+        std::vector<spdlog::sink_ptr> logSink;
+        logSink.emplace_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+
+        spdlog::set_pattern("%^[%T] %n: %v%$");
+        m_EngineLogger = std::make_shared<spdlog::logger>("Engine", begin(logSink), end(logSink));
+        if (m_EngineLogger) {
+            ok = true;
+            spdlog::register_logger(m_EngineLogger);
+            m_EngineLogger->set_level(spdlog::level::trace);
+            m_EngineLogger->flush_on(spdlog::level::trace);
+        }
+
+        m_AppLogger = std::make_shared<spdlog::logger>("Application", begin(logSink), end(logSink));
+        if (m_AppLogger) {
+            ok = true;
+            spdlog::register_logger(m_AppLogger);
+            m_EngineLogger->set_level(spdlog::level::trace);
+            m_EngineLogger->flush_on(spdlog::level::trace);
+        }
+
+        return ok;
+    }
+}

--- a/engine/log/log.hpp
+++ b/engine/log/log.hpp
@@ -1,0 +1,30 @@
+
+
+#pragma once
+
+#include <memory>
+
+#include "spdlog/spdlog.h"
+#include <spdlog/fmt/ostr.h>
+
+namespace VGED
+{
+    class Log {
+    public:
+        static bool init();
+
+        inline static std::shared_ptr<spdlog::logger>& getLogger() {
+            return m_EngineLogger;
+        }
+
+        inline static std::shared_ptr<spdlog::logger>& getAppLogger() {
+            return m_AppLogger;
+        }
+
+    private: 
+
+        static std::shared_ptr<spdlog::logger> m_EngineLogger;
+        static std::shared_ptr<spdlog::logger> m_AppLogger;
+
+    };
+}

--- a/engine/vged.hpp
+++ b/engine/vged.hpp
@@ -1,0 +1,64 @@
+/* VGED Copyright (c) 2022 VGED ORGANIZATION
+   https://github.com/VGED-ORGANIZATION/VGED-ENGINE
+   License: GPL-3
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation files
+   (the "Software"), to deal in the Software without restriction,
+   including without limitation the rights to use, copy, modify, merge,
+   publish, distribute, sublicense, and/or sell copies of the Software,
+   and to permit persons to whom the Software is furnished to do so,
+   subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
+
+#pragma once
+
+#include <iostream>
+#include "log/log.hpp"
+
+#undef far
+#undef near
+#undef CopyFile
+#undef CreateDirectory
+#undef CreateWindow
+
+#define ASSERT(x) if (!(x)) std::cout << " (ASSERT on line number " << __LINE__ << " in file " << __FILE__ << ")" << std::endl;
+#define memberSize(type, member) sizeof(((type *)0)->member)
+#define BIT(x) (1 << (x))
+
+#define LOG_CORE_TRACE(...)     VGED::Log::getLogger()->trace(__VA_ARGS__)
+#define LOG_CORE_INFO(...)      VGED::Log::getLogger()->info(__VA_ARGS__)
+#define LOG_CORE_WARN(...)      VGED::Log::getLogger()->warn(__VA_ARGS__)
+#define LOG_CORE_ERROR(...)     VGED::Log::getLogger()->error(__VA_ARGS__)
+#define LOG_CORE_CRITICAL(...)  VGED::Log::getLogger()->critical(__VA_ARGS__)
+
+#define LOG_APP_TRACE(...)      VGED::Log::getAppLogger()->trace(__VA_ARGS__)
+#define LOG_APP_INFO(...)       VGED::Log::getAppLogger()->info(__VA_ARGS__)
+#define LOG_APP_WARN(...)       VGED::Log::getAppLogger()->warn(__VA_ARGS__)
+#define LOG_APP_ERROR(...)      VGED::Log::getAppLogger()->error(__VA_ARGS__)
+#define LOG_APP_CRITICAL(...)   VGED::Log::getAppLogger()->critical(__VA_ARGS__)
+
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
+using usize = std::size_t;
+
+using i8 = std::int8_t;
+using i16 = std::int16_t;
+using i32 = std::int32_t;
+using i64 = std::int64_t;
+using isize = std::ptrdiff_t;
+
+using f32 = float;
+using f64 = double;


### PR DESCRIPTION
example_game is broken at the moment because

main.cpp:(.text+0x76): multiple definition of `main'; CMakeFiles/example_game.dir/build/CMakeFiles/3.16.3/CompilerIdCXX/CMakeCXXCompilerId.cpp.o:CMakeCXXCompilerId.cpp:(.text+0x0): first defined here

it has something to do with GLOB_RECURSE from https://github.com/beaumanvienna/VGED-ENGINE/blob/267376adab6a38db56055547c4bd256f8913e530/application/example_game/CMakeLists.txt#L4

I changed main() to _main() for example_game, so that it at least compiles
